### PR TITLE
fix(utils): refactor GraphQL queries for username functions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,13 +50,13 @@ export async function fetchUsername(address: string) {
 
 export async function fetchUsernames(addresses: string[]) {
   const input = addresses
-    .map((address) => `"${address}"`)
+    .map((address) => `{ addressHasPrefix: "${address}" }`)
     .join(',')
   // language=graphql
   const query = `query {
     accounts(where: {
       hasControllersWith: {
-        addressIn: [${input}]
+        or: [${input}]
       }
     }) {
       edges {


### PR DESCRIPTION
Refactored GraphQL query construction in fetchUsername and fetchUsernames for breaking changes.
Switched from inline query strings to template literals.

ToDo:

- [x] get rid of prefix matching and make sure it works with the new diff (`addressIn`)