### PR TITLE
fix(utils): handle nested edges in account controllers

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,8 +65,12 @@ export async function fetchUsernames(addresses: string[]) {
         node {
           id
           controllers {
-            id
-            address
+            edges {
+              node {
+                id
+                address
+              }
+            }
           }
         }
       }
@@ -85,25 +89,27 @@ export async function fetchUsernames(addresses: string[]) {
   ).json()) as {
     data: {
       accounts: {
-        edges:
-          | {
-              node: {
-                id: string
-                controllers: {
+        edges: {
+          node: {
+            id: string
+            controllers: {
+              edges: {
+                node: {
                   id: string
                   address: string
-                }[]
-              } | null
-            }[]
-          | null
+                } | null
+              }[]
+            }
+          } | null
+        }[] | null
       } | null
     }
   }
 
   return data.data.accounts.edges.reduce((acc, account) => {
-    for (const controller of account?.node?.controllers) {
-      acc[controller.address] = account.node.id
-      acc[maskAddress(controller.address)] = account.node.id
+    for (const controller of account?.node?.controllers.edges || []) {
+      acc[controller.node.address] = account.node.id
+      acc[maskAddress(controller.node.address)] = account.node.id
     }
     return acc
   }, {})


### PR DESCRIPTION
Adjusted the GraphQL query and data processing logic to handle nested edges in account controllers. This ensures proper extraction of controller addresses.